### PR TITLE
fix:修复因flink任务完成过快导致任务被标记为失败

### DIFF
--- a/flink-streaming-web-common/src/main/java/com/flink/streaming/web/common/SystemConstants.java
+++ b/flink-streaming-web-common/src/main/java/com/flink/streaming/web/common/SystemConstants.java
@@ -16,7 +16,9 @@ public class SystemConstants {
     public static final String COOKIE_NAME_SESSION_ID = "flink-streaming-platform-web-sessionid";
 
     public static final String STATUS_RUNNING = "RUNNING";
-    
+
+    public static final String STATUS_FINISHED = "FINISHED";
+
     public static final String STATUS_RESTARTING = "RESTARTING";
 
     public static final String USER_NAME_TASK_AUTO = "task-auto";

--- a/flink-streaming-web/src/main/java/com/flink/streaming/web/ao/impl/JobBaseServiceAOImpl.java
+++ b/flink-streaming-web/src/main/java/com/flink/streaming/web/ao/impl/JobBaseServiceAOImpl.java
@@ -356,7 +356,8 @@ public class JobBaseServiceAOImpl implements JobBaseServiceAO {
                     localLog.append("\n 任务失败 appId=" + appId);
                     throw new BizException("任务失败");
                 } else {
-                    if (!SystemConstants.STATUS_RUNNING.equals(jobStandaloneInfo.getState())) {
+                    if (!SystemConstants.STATUS_RUNNING.equals(jobStandaloneInfo.getState())
+                        && !SystemConstants.STATUS_FINISHED.equals(jobStandaloneInfo.getState())) {
                         localLog.append("\n 任务失败 appId=" + appId).append("状态是：" + jobStandaloneInfo.getState());
                         throw new BizException("[submitJobForStandalone]任务失败");
                     }


### PR DESCRIPTION
当一个flink任务完成的太快时（通常在3s内），因判断时仅匹配是否为RUNNING而导致的BUG